### PR TITLE
threadlocal leak causes metaspace oom

### DIFF
--- a/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxProtector.java
+++ b/sandbox-core/src/main/java/com/alibaba/jvm/sandbox/core/util/SandboxProtector.java
@@ -69,7 +69,12 @@ public class SandboxProtector {
      * @return TRUE:在守护区域中；FALSE：非守护区域中
      */
     public boolean isInProtecting() {
-        return isInProtectingThreadLocal.get().get() > 0;
+        AtomicInteger inProtect = isInProtectingThreadLocal.get();
+        if (inProtect.get() <= 0) {
+            isInProtectingThreadLocal.remove();
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
多次挂载&卸载最终metaspace 溢出
![image](https://user-images.githubusercontent.com/28588342/174539115-c3d494e4-80be-43a1-91a2-37dac0ac2253.png)


持续上升 没有回收
![image](https://user-images.githubusercontent.com/28588342/174539148-112c9deb-ff14-471d-aeb9-47f011b28e3e.png)



thread local泄漏
![image](https://user-images.githubusercontent.com/28588342/174539180-b959e43e-13a3-43a8-b0f5-970a63596d27.png)


Process threadLocal 泄漏以及 SandboxProcector isInProtectingThreadLocal 泄漏 导致sandbox classloader无法在gc时被回收，从而导致它加载的class一直存在与metaspace中，多次挂载&卸载后oom。